### PR TITLE
PRICE_FILTER fix: roundTicks now rounds price with tickSize

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -1498,17 +1498,29 @@ class API
     }
     
     /**
-     * roundStep rounds number with given step
-     * @param $value price
+     * roundStep rounds quantity with stepSize
+     * @param $qty quantity
      * @param $stepSize parameter from exchangeInfo
      * @return rounded value. example: roundStep(1.2345, 0.1) = 1.2
      *
      */
-    public function roundStep($value, $stepSize = 0.1) {
+    public function roundStep($qty, $stepSize = 0.1) {
         $precision = strlen(substr(strrchr(rtrim($stepSize,'0'), '.'), 1));
-        return round((($value / $stepSize) | 0) * $stepSize, $precision);
+        return round((($qty / $stepSize) | 0) * $stepSize, $precision);
     }
-
+    
+    /**
+     * roundTicks rounds price with tickSize
+     * @param $value price
+     * @param $tickSize parameter from exchangeInfo
+     * @return rounded value. example: roundStep(1.2345, 0.1) = 1.2
+     *
+     */
+    public function roundTicks($price, $tickSize) {
+        $precision = strlen(rtrim(substr($tickSize,strpos($tickSize, '.', 1) + 1), '0'));
+        return number_format($price, $precision, '.', '');
+    }
+    
     /**
      * getTransfered gets the total transfered in b,Kb,Mb,Gb
      *

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -1505,7 +1505,7 @@ class API
      *
      */
     public function roundStep($value, $stepSize = 0.1) {
-        $precision = strlen(substr(strrchr(rtrim($value,'0'), '.'), 1));
+        $precision = strlen(substr(strrchr(rtrim($stepSize,'0'), '.'), 1));
         return round((($value / $stepSize) | 0) * $stepSize, $precision);
     }
 


### PR DESCRIPTION
> roundTicks: Used to round price with tickSize. Example: `roundTicks(0.12345, '0.001') = 0.123`
```php
function roundTicks($price, $tickSize) {
        $precision = strlen(rtrim(substr($tickSize,strpos($tickSize, '.', 1) + 1), '0'));
        return number_format($price, $precision, '.', '');
}
echo roundTicks(0.00016552, '0.00000010');
```