### PR TITLE
Add extra parameters to cancel function

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -363,15 +363,17 @@ class API
      *
      * @param $symbol string the currency symbol
      * @param $orderid string the orderid to cancel
+     * @param $flags array of optional options like ["side"=>"sell"]
      * @return array with error message or the order details
      * @throws \Exception
      */
-    public function cancel(string $symbol, $orderid)
+    public function cancel(string $symbol, $orderid, $flags = [])
     {
-        return $this->httpRequest("v3/order", "DELETE", [
+        $params = [
             "symbol" => $symbol,
             "orderId" => $orderid,
-        ], true);
+        ];
+        return $this->httpRequest("v3/order", "DELETE", array_merge($params, $flags), true);
     }
 
     /**


### PR DESCRIPTION
Added extra parameters to `cancel` function

Example:
`$answer = $api->cancel("BTCUSDT", "177688888", ["side"=>"sell"]);`